### PR TITLE
SOUS-42: Add News content type to sous warp whistle project 

### DIFF
--- a/config/core.entity_form_display.node.news.default.yml
+++ b/config/core.entity_form_display.node.news.default.yml
@@ -1,0 +1,278 @@
+uuid: ed48da22-5561-4af1-baea-d509ea4bb76a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.news.field_content
+    - field.field.node.news.field_metadata
+    - field.field.node.news.field_news_category
+    - field.field.node.news.field_seo_title
+    - field.field.node.news.field_subtitle
+    - field.field.node.news.field_tags
+    - field.field.node.news.field_teaser_image
+    - field.field.node.news.field_teaser_text
+    - node.type.news
+  module:
+    - field_group
+    - field_states_ui
+    - media_library
+    - metatag
+    - paragraphs
+    - paragraphs_ee
+    - paragraphs_features
+    - publication_date
+third_party_settings:
+  field_group:
+    group_tabs:
+      children:
+        - group_header
+        - group_teaser
+        - group_news_details
+        - group_main_content
+        - group_taxonomy
+      label: Tabs
+      region: content
+      parent_name: ''
+      weight: 0
+      format_type: tabs
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        direction: horizontal
+        width_breakpoint: 640
+    group_header:
+      children:
+        - title
+        - field_seo_title
+        - field_subtitle
+      label: Header
+      region: content
+      parent_name: group_tabs
+      weight: 1
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        formatter: open
+        description: ''
+        required_fields: true
+    group_teaser:
+      children:
+        - field_teaser_image
+        - field_teaser_text
+      label: Teaser
+      region: content
+      parent_name: group_tabs
+      weight: 2
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_news_details:
+      children:
+        - field_news_category
+      label: 'News Details'
+      region: content
+      parent_name: group_tabs
+      weight: 3
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_main_content:
+      children:
+        - field_content
+      label: 'Main Content'
+      region: content
+      parent_name: group_tabs
+      weight: 4
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        formatter: closed
+        description: ''
+        required_fields: true
+    group_taxonomy:
+      children:
+        - field_tags
+      label: Taxonomy
+      region: content
+      parent_name: group_tabs
+      weight: 5
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        formatter: closed
+        description: ''
+        required_fields: true
+id: node.news.default
+targetEntityType: node
+bundle: news
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_content:
+    type: paragraphs
+    weight: 8
+    region: content
+    settings:
+      title: Component
+      title_plural: Components
+      edit_mode: open
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: _none
+      features:
+        add_above: add_above
+        collapse_edit_all: collapse_edit_all
+        convert: '0'
+        duplicate: '0'
+    third_party_settings:
+      paragraphs_features:
+        add_in_between: false
+        add_in_between_link_count: 3
+        delete_confirmation: true
+        show_drag_and_drop: true
+        show_collapse_all: true
+      field_states_ui:
+        form:
+          type: ''
+          list: ''
+          add: Add
+      paragraphs_ee:
+        paragraphs_ee:
+          dialog_off_canvas: false
+          dialog_style: tiles
+  field_metadata:
+    type: metatag_firehose
+    weight: 7
+    region: content
+    settings:
+      sidebar: true
+      use_details: true
+    third_party_settings: {  }
+  field_news_category:
+    type: entity_reference_autocomplete
+    weight: 8
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_seo_title:
+    type: string_textfield
+    weight: 3
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_subtitle:
+    type: string_textfield
+    weight: 4
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_tags:
+    type: entity_reference_autocomplete
+    weight: 8
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_teaser_image:
+    type: media_library_widget
+    weight: 2
+    region: content
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+  field_teaser_text:
+    type: string_textarea
+    weight: 3
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    weight: 4
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  published_at:
+    type: publication_date_timestamp
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 6
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    weight: 5
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 1
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/config/core.entity_form_display.node.news.default.yml
+++ b/config/core.entity_form_display.node.news.default.yml
@@ -14,7 +14,6 @@ dependencies:
     - node.type.news
   module:
     - field_group
-    - field_states_ui
     - media_library
     - metatag
     - paragraphs
@@ -162,11 +161,6 @@ content:
         delete_confirmation: true
         show_drag_and_drop: true
         show_collapse_all: true
-      field_states_ui:
-        form:
-          type: ''
-          list: ''
-          add: Add
       paragraphs_ee:
         paragraphs_ee:
           dialog_off_canvas: false

--- a/config/core.entity_view_display.node.news.default.yml
+++ b/config/core.entity_view_display.node.news.default.yml
@@ -1,0 +1,66 @@
+uuid: 8e1fa322-1ebf-43bb-8f59-96ca253e74ae
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.news.field_content
+    - field.field.node.news.field_metadata
+    - field.field.node.news.field_news_category
+    - field.field.node.news.field_seo_title
+    - field.field.node.news.field_subtitle
+    - field.field.node.news.field_tags
+    - field.field.node.news.field_teaser_image
+    - field.field.node.news.field_teaser_text
+    - node.type.news
+  module:
+    - entity_reference_revisions
+    - user
+id: node.news.default
+targetEntityType: node
+bundle: news
+mode: default
+content:
+  field_content:
+    type: entity_reference_revisions_entity_view
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_news_category:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_subtitle:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_tags:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_metadata: true
+  field_seo_title: true
+  field_teaser_image: true
+  field_teaser_text: true
+  published_at: true

--- a/config/core.entity_view_display.node.news.teaser.yml
+++ b/config/core.entity_view_display.node.news.teaser.yml
@@ -1,0 +1,51 @@
+uuid: b9dd2a6d-6ea7-4dd1-8cee-b8b1ec1f66bc
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.news.field_content
+    - field.field.node.news.field_metadata
+    - field.field.node.news.field_news_category
+    - field.field.node.news.field_seo_title
+    - field.field.node.news.field_subtitle
+    - field.field.node.news.field_tags
+    - field.field.node.news.field_teaser_image
+    - field.field.node.news.field_teaser_text
+    - node.type.news
+  module:
+    - user
+id: node.news.teaser
+targetEntityType: node
+bundle: news
+mode: teaser
+content:
+  field_teaser_image:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: default
+      link: true
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_teaser_text:
+    type: basic_string
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  field_content: true
+  field_metadata: true
+  field_news_category: true
+  field_seo_title: true
+  field_subtitle: true
+  field_tags: true
+  published_at: true

--- a/config/field.field.node.news.field_content.yml
+++ b/config/field.field.node.news.field_content.yml
@@ -1,0 +1,46 @@
+uuid: cf893c03-dd3e-4981-8eb8-cc1b0d80796e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_content
+    - node.type.news
+    - paragraphs.paragraphs_type.image
+    - paragraphs.paragraphs_type.text
+    - paragraphs.paragraphs_type.text_with_media
+    - paragraphs.paragraphs_type.video
+  module:
+    - entity_reference_revisions
+id: node.news.field_content
+field_name: field_content
+entity_type: node
+bundle: news
+label: Content
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      image: image
+      text: text
+      text_with_media: text_with_media
+      video: video
+    negate: 0
+    target_bundles_drag_drop:
+      image:
+        weight: 5
+        enabled: true
+      text:
+        weight: 6
+        enabled: true
+      text_with_media:
+        weight: 7
+        enabled: true
+      video:
+        weight: 8
+        enabled: true
+field_type: entity_reference_revisions

--- a/config/field.field.node.news.field_metadata.yml
+++ b/config/field.field.node.news.field_metadata.yml
@@ -1,0 +1,21 @@
+uuid: 1ea6ebd2-d738-4fd4-9947-5714b9074d70
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_metadata
+    - node.type.news
+  module:
+    - metatag
+id: node.news.field_metadata
+field_name: field_metadata
+entity_type: node
+bundle: news
+label: Metadata
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/config/field.field.node.news.field_news_category.yml
+++ b/config/field.field.node.news.field_news_category.yml
@@ -1,0 +1,29 @@
+uuid: bc20beba-83e5-44bd-884f-add2027394b5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_news_category
+    - node.type.news
+    - taxonomy.vocabulary.news_category
+id: node.news.field_news_category
+field_name: field_news_category
+entity_type: node
+bundle: news
+label: 'News Category'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      news_category: news_category
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.news.field_seo_title.yml
+++ b/config/field.field.node.news.field_seo_title.yml
@@ -1,0 +1,19 @@
+uuid: a27156c3-24ee-46f7-8d4f-6136b242fdc9
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_seo_title
+    - node.type.news
+id: node.news.field_seo_title
+field_name: field_seo_title
+entity_type: node
+bundle: news
+label: 'Seo Title'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.node.news.field_subtitle.yml
+++ b/config/field.field.node.news.field_subtitle.yml
@@ -1,0 +1,19 @@
+uuid: 2c305394-c8b9-4e30-b3ae-1cdf73479851
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_subtitle
+    - node.type.news
+id: node.news.field_subtitle
+field_name: field_subtitle
+entity_type: node
+bundle: news
+label: Subtitle
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.node.news.field_tags.yml
+++ b/config/field.field.node.news.field_tags.yml
@@ -1,0 +1,29 @@
+uuid: 61706bae-ef23-43bd-a0ee-0671f2d9ea79
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_tags
+    - node.type.news
+    - taxonomy.vocabulary.tags
+id: node.news.field_tags
+field_name: field_tags
+entity_type: node
+bundle: news
+label: Tags
+description: 'Global taxonomy for all content.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      tags: tags
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.news.field_teaser_image.yml
+++ b/config/field.field.node.news.field_teaser_image.yml
@@ -1,0 +1,29 @@
+uuid: 8c0f47a3-3acd-48d5-934d-5b87eed13bfa
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_teaser_image
+    - media.type.image
+    - node.type.news
+id: node.news.field_teaser_image
+field_name: field_teaser_image
+entity_type: node
+bundle: news
+label: 'Teaser Image'
+description: 'Used when this page appears in listings and site-wide search. Also used when sharing on social networks. For best results should be at least 2000px wide.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.node.news.field_teaser_text.yml
+++ b/config/field.field.node.news.field_teaser_text.yml
@@ -1,0 +1,19 @@
+uuid: 6285e838-e9a5-42c9-b116-deb820593dfe
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_teaser_text
+    - node.type.news
+id: node.news.field_teaser_text
+field_name: field_teaser_text
+entity_type: node
+bundle: news
+label: 'Teaser Text'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/field.storage.node.field_news_category.yml
+++ b/config/field.storage.node.field_news_category.yml
@@ -1,0 +1,20 @@
+uuid: 2ab2b75f-ddd9-4542-ba31-d54e87ddbd8c
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_news_category
+field_name: field_news_category
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/node.type.news.yml
+++ b/config/node.type.news.yml
@@ -1,0 +1,11 @@
+uuid: 1f3a0f7d-8ae2-4c81-a194-d211ae32445b
+langcode: en
+status: true
+dependencies: {  }
+name: News
+type: news
+description: null
+help: null
+new_revision: true
+preview_mode: 1
+display_submitted: true

--- a/config/taxonomy.vocabulary.news_category.yml
+++ b/config/taxonomy.vocabulary.news_category.yml
@@ -1,0 +1,9 @@
+uuid: 1a9b51a0-af6b-4e93-b1c0-f8444db408be
+langcode: en
+status: true
+dependencies: {  }
+name: 'News Category'
+vid: news_category
+description: null
+weight: 0
+new_revision: false


### PR DESCRIPTION
**This PR does the following:**
- Adds configuration for Warp Whistle News content type
  
### Ticket(s)
- [SOUS-42: Add News content type to sous warp whistle project](https://app.clickup.com/t/36718269/SOUS-42)

### Functional Testing:
- [ ] Import configuration
- [ ] Verify that the News content type exists and matches [the spec](https://coda.io/d/_dLnuNJT7f71/Content-types_suPV5MDF#News_tuq3oPfv)